### PR TITLE
Add navigation args to `SavedStateHandle`

### DIFF
--- a/koin-androidx-compose/build.gradle
+++ b/koin-androidx-compose/build.gradle
@@ -60,7 +60,7 @@ dependencies {
 
     // Compose
     api "androidx.lifecycle:lifecycle-viewmodel-compose:2.4.1"
-    api "androidx.navigation:navigation-compose:2.5.0"
+    api "androidx.navigation:navigation-compose:2.4.2"
     api "androidx.compose.runtime:runtime:$androidx_compose_version"
     api "androidx.compose.ui:ui:$androidx_compose_version"
 

--- a/koin-androidx-compose/build.gradle
+++ b/koin-androidx-compose/build.gradle
@@ -60,6 +60,7 @@ dependencies {
 
     // Compose
     api "androidx.lifecycle:lifecycle-viewmodel-compose:2.4.1"
+    api "androidx.navigation:navigation-compose:2.5.0"
     api "androidx.compose.runtime:runtime:$androidx_compose_version"
     api "androidx.compose.ui:ui:$androidx_compose_version"
 

--- a/koin-androidx-compose/src/main/java/org/koin/androidx/compose/ViewModelComposeExt.kt
+++ b/koin-androidx-compose/src/main/java/org/koin/androidx/compose/ViewModelComposeExt.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.navigation.NavBackStackEntry
 import org.koin.androidx.viewmodel.ViewModelParameter
 import org.koin.androidx.viewmodel.ext.android.getViewModelFactory
 import org.koin.androidx.viewmodel.scope.BundleDefinition
@@ -53,8 +54,9 @@ inline fun <reified T : ViewModel> getViewModel(
 ): T {
     return remember(qualifier, parameters) {
         val vmClazz = T::class
+        val state = (owner as? NavBackStackEntry)?.arguments
         val factory = getViewModelFactory(
-            owner, vmClazz, qualifier, parameters, scope = scope
+            owner, vmClazz, qualifier, parameters, scope = scope, state = state?.let { {it} }
         )
         ViewModelProvider(owner, factory).get(vmClazz.java)
     }


### PR DESCRIPTION
Navigation arguments can be passed when navigating to a destination. These arguments can be passed down to `SavedStateHandle` which can be accessed directly in the `ViewModel`.